### PR TITLE
Make STS assume role optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,11 @@ A simple utility for fetching a secret from AWS secrets manager into file that c
 ## Usage
 
 ```bash
+npx fetch-secrets --output ./fileToAppendTo.sh --secret arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:secret:someSecretName
+```
+
+**With automatic role assumption**
+
+```bash
 npx fetch-secrets --output ./fileToAppendTo.sh --role arn:aws:iam::${AWS_ACCOUNT_ID}:role/some-role --secret arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:secret:someSecretName
 ```

--- a/fetch-secret.js
+++ b/fetch-secret.js
@@ -20,7 +20,7 @@ const commandLineOptions = [
         alias: 'r',
         type: String,
         typeLabel: '{underline AWS ARN}',
-        description: 'Role ARN to assume for fetching secret'
+        description: 'Optional role ARN to assume when fetching secret'
     },
     {
         name: 'secret',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,14 @@
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "aws-sdk": {
-      "version": "2.478.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.478.0.tgz",
-      "integrity": "sha512-IN1Rl8PO+dzq00xmPitugC+daQp68jWYgW90kv1OMW5A6saFLpeiGrRiAtoYFmZO7VXrEO5WilLf9PkBkXo+kg==",
+      "version": "2.1098.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1098.0.tgz",
+      "integrity": "sha512-h81SAgqAxij1db9zbFAXEneaC1LNcx/xIIf13tF/IutdYOzd7mQ3lHFCgjp+fB1Msl8z73Vs0VGstyrhK7+zPw==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
-        "jmespath": "0.15.0",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -34,14 +34,14 @@
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -72,39 +72,36 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "requires": {
-        "array-back": "^3.0.1",
+        "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
       }
     },
     "command-line-usage": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
-      "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
       "requires": {
-        "array-back": "^2.0.0",
-        "chalk": "^2.4.1",
-        "table-layout": "^0.4.3",
-        "typical": "^2.6.1"
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
       },
       "dependencies": {
         "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "requires": {
-            "typical": "^2.6.1"
-          }
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
         },
         "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
         }
       }
     },
@@ -137,9 +134,9 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -147,19 +144,14 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
     },
     "punycode": {
       "version": "1.3.2",
@@ -172,9 +164,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
     "sax": {
       "version": "1.2.1",
@@ -190,29 +182,25 @@
       }
     },
     "table-layout": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
-      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "requires": {
-        "array-back": "^2.0.0",
+        "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
       },
       "dependencies": {
         "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "requires": {
-            "typical": "^2.6.1"
-          }
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
         },
         "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
         }
       }
     },
@@ -236,18 +224,18 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
       },
       "dependencies": {
         "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "bash",
     "cli"
   ],
+  "engines": {
+      "node": ">=8.0.0"
+  },
   "author": "Andy Desmarais <terodox@gmail.com>",
   "license": "MIT",
   "bugs": {
@@ -29,8 +32,8 @@
   },
   "homepage": "https://github.com/terodox/fetch-secret#readme",
   "dependencies": {
-    "aws-sdk": "2.478.0",
-    "command-line-args": "5.1.1",
-    "command-line-usage": "5.0.5"
+    "aws-sdk": "2.1098.0",
+    "command-line-args": "5.2.1",
+    "command-line-usage": "6.1.1"
   }
 }


### PR DESCRIPTION
This makes assuming a role optional for fetching a secret.

This is useful for situations where

- another mechanism is used to assume the appropriate role (e.g. [@meltwater/awsudo])
- the currently authenticated AWS user doesn't need to assume a role to fetch the secret

## Changes

### Functional

- If role option is omitted
    1. skip assume role operation
    2. provide no credentials when getting secret value from Secrets Manager
- Update help text
    - Typo

### Internal

* Update dependencies
    * `command-line-usage` only supports node 8.0.0+ as of this update
* Note `engines` in `package.json` to reflect requirement inherited from `command-line-usage`
* split retrieval of credentials from role into `getCredentialsForRole`
    * returns full credential set meant for `AWS.SecretManager`
* `getSecretWithCredentials` accepts a full credential set meant for `AWS.SecretManager`
    * allows `undefined` via usage of spread operator
* if role option is provided
    1. get credentials from `getCredentialsForRole`
    3. pass those credentials, or `undefined`, to `getSecretWithCredentials`

## Testing

- Node v8
- Specified `-r`
    - Functions as previously
    - Specified secret by its ARN
- Omitting `-r`
    - Used [@meltwater/awsudo] to set up an environment with a role already assumed
    - Specified secret by name only

### Updated help test

```
Fetch Secrets

  Fetch secrets from secrets manager and output to a file

Options

  -o, --output file               File path to output secrets JSON
  -r, --role AWS ARN              Role ARN to assume for fetching secret
  -s, --secret AWS ARN | string   Secret ARN/name to read
  -h, --help                      Display usage
```

[@meltwater/awsudo]: https://github.com/meltwater/awsudo/